### PR TITLE
moves "anime" text; removes code that crashes the keyboard

### DIFF
--- a/Keyboard/Keyboard.xib
+++ b/Keyboard/Keyboard.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -16,7 +16,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H4b-eq-gPx">
-                    <rect key="frame" x="176" y="358" width="44" height="30"/>
+                    <rect key="frame" x="165" y="0.0" width="44" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <state key="normal" title="Anime"/>
                 </button>
@@ -25,6 +25,7 @@
             <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.94999999999999996"/>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="34.5" y="54.5"/>
         </view>
     </objects>
 </document>

--- a/Keyboard/KeyboardViewController.swift
+++ b/Keyboard/KeyboardViewController.swift
@@ -53,15 +53,6 @@ class KeyboardViewController: UIInputViewController {
     
     override func textDidChange(_ textInput: UITextInput?) {
         // The app has just changed the document's contents, the document context has been updated.
-        
-        var textColor: UIColor
-        let proxy = self.textDocumentProxy
-        if proxy.keyboardAppearance == UIKeyboardAppearance.dark {
-            textColor = UIColor.white
-        } else {
-            textColor = UIColor.black
-        }
-        self.nextKeyboardButton.setTitleColor(textColor, for: [])
     }
 
 }


### PR DESCRIPTION
I was getting the following error when trying to switch to this custom keyboard:

```
fatal error: unexpectedly found nil while unwrapping an Optional value
```
on this line:
```
        self.nextKeyboardButton.setTitleColor(textColor, for: [])
```

I don't believe the logic in `textDidChange` belongs there. I'm removing it so that the keyboard launches.
